### PR TITLE
os.Stdout.Write writes to Xen console

### DIFF
--- a/src/os/file_atman.go
+++ b/src/os/file_atman.go
@@ -1,5 +1,7 @@
 package os
 
+import "syscall"
+
 type File struct {
 	fd      int
 	name    string
@@ -35,8 +37,8 @@ func (*File) pread(b []byte, off int64) (n int, err error) {
 	return 0, ErrNotExist
 }
 
-func (*File) write(b []byte) (n int, err error) {
-	return 0, ErrNotExist
+func (f *File) write(b []byte) (n int, err error) {
+	return syscall.Write(f.fd, b)
 }
 
 func (*File) pwrite(b []byte, off int64) (n int, err error) {

--- a/src/runtime/sys_atman.go
+++ b/src/runtime/sys_atman.go
@@ -51,7 +51,7 @@ type xenStartInfo struct {
 	StoreEventchn  uint32
 	_              [4]byte
 	Console        struct {
-		Mfn      uint64 // machine page number of console page
+		Mfn      mfn    // machine page number of console page
 		Eventchn uint32 // event channel
 		_        [4]byte
 	}
@@ -129,6 +129,8 @@ func atmaninit() {
 	println("     cmd_line: ", _atman_start_info.CmdLine[:])
 	println("    first_pfn: ", _atman_start_info.FirstP2mPfn)
 	println("nr_p2m_frames: ", _atman_start_info.NrP2mFrames)
+
+	_atman_console.init()
 
 	println("setting _atman_phys_to_machine_mapping")
 	_atman_phys_to_machine_mapping = *(*[8192]uint64)(unsafe.Pointer(

--- a/src/syscall/syscall_atman.go
+++ b/src/syscall/syscall_atman.go
@@ -98,3 +98,19 @@ func Mkdir(path string, perm uint32) error {
 }
 
 func Exit(code int) {}
+
+// Write writes the contents of b to fd and returns
+// the number of bytes written or an error.
+//
+// If fd is Stdout, b is written with WriteConsole.
+func Write(fd int, b []byte) (n int, err error) {
+	if fd != 1 {
+		return 0, EINVAL
+	}
+
+	return WriteConsole(b), nil
+}
+
+// WriteConsole writes b to the Xen console and
+// returns the number of bytes written.
+func WriteConsole(b []byte) int


### PR DESCRIPTION
The runtime now exports a `systall.WriteConsole` function for writing to
the Xen console. Calling `os.Stdout.Write` or
`syscall.Write(syscall.Stdout)` will use this function to write to the
console.
