### PR TITLE
Initial support for Xen events

### DIFF
--- a/src/runtime/event_atman.go
+++ b/src/runtime/event_atman.go
@@ -2,7 +2,19 @@ package runtime
 
 import "unsafe"
 
+func initEvents() {
+	HYPERVISOR_set_callbacks(
+		funcPC(hypervisorEventCallback),
+		funcPC(hypervisorFailsafeCallback),
+	)
+
+	enableIRQ()
+	bindVIRQ()
+}
+
 // clearbit atomically clears the bit at offset n from addr.
+//
+//go:nosplit
 func clearbit(addr *uint64, n uint32)
 
 func eventChanSend(port uint32) {
@@ -18,7 +30,60 @@ func eventChanSend(port uint32) {
 	}
 }
 
+//go:nosplit
 func unmaskEventChan(port uint32) {
 	info := _atman_shared_info
 	clearbit(&info.EvtchnMask[0], port)
+}
+
+//go:nosplit
+func clearEventChan(port uint32) {
+	info := _atman_shared_info
+	clearbit(&info.EvtchnPending[0], port)
+}
+
+// enableIRQ enables interrupts clearing the event mask
+// on the shared VCPU structure.
+//
+//go:nosplit
+func enableIRQ() {
+	vcpu := &_atman_shared_info.VCPUInfo[0]
+	vcpu.UpcallMask = 0
+}
+
+//go:nosplit
+func hypervisorEventCallback()
+
+//go:nosplit
+func hypervisorFailsafeCallback()
+
+//go:nosplit
+func handleHypervisorCallback(r *cpuRegisters) {
+	_atman_shared_info.VCPUInfo[0].UpcallPending = 0
+	_atman_shared_info.VCPUInfo[0].PendingSel = 0
+	_atman_shared_info.EvtchnPending[0] = 0
+}
+
+func bindVIRQ() {
+	op := struct {
+		VIRQ uint32
+		VCPU uint32
+
+		// Port is set on success
+		Port uint32
+	}{
+		VIRQ: 0, // VIRQ_TIMER,
+		VCPU: 0,
+	}
+
+	ret := HYPERVISOR_event_channel_op(
+		1, // EVTCHNOP_bind_virq
+		unsafe.Pointer(&op),
+	)
+
+	if ret != 0 {
+		println("HYPERVISOR_event_channel_op returned", ret)
+	}
+
+	println("Bound VIRQ to Port", op.Port)
 }

--- a/src/runtime/event_atman_amd64.s
+++ b/src/runtime/event_atman_amd64.s
@@ -1,6 +1,80 @@
+#include "textflag.h"
+
 // func clearbit(addr *uint64, n uint32)
 TEXT ·clearbit(SB),NOSPLIT,$0-12
-	MOVQ	addr+0(FP), BX
-	MOVL	n+8(FP), AX
+	MOVQ	addr+0(FP), AX
+	MOVL	n+8(FP), BX
 	LOCK
-	BTRQ	AX, 0(BX)
+	BTRQ	BX, (AX)
+	RET
+
+TEXT ·hypervisorEventCallback(SB),NOSPLIT,$0
+	MOVQ	0(SP), CX
+	MOVQ	8(SP), R11
+	ADDQ	$16, SP	// ignore CX, R11
+
+	// Store $0 in code slot
+	SUBQ	$8, SP
+	MOVQ	$0x0, 0(SP)	// $0 in code
+
+	// Save registers to stack
+	SUBQ	$15*8, SP
+	MOVQ	DI, 14*8(SP)
+	MOVQ	SI, 13*8(SP)
+	MOVQ	DX, 12*8(SP)
+	MOVQ	CX, 11*8(SP)
+	MOVQ	AX, 10*8(SP)
+	MOVQ	R8, 9*8(SP)
+	MOVQ	R9, 8*8(SP)
+	MOVQ	R10, 7*8(SP)
+	MOVQ	R11, 6*8(SP)
+	MOVQ	BX, 5*8(SP)
+	MOVQ	BP, 4*8(SP)
+	MOVQ	R12, 3*8(SP)
+	MOVQ	R13, 2*8(SP)
+	MOVQ	R14, 1*8(SP)
+	MOVQ	R15, 0*8(SP)
+
+	// Call handleHypervisorCallback with pointer
+	// to registers
+	MOVQ	SP, AX
+	SUBQ	$8, SP
+	MOVQ	AX, 0(SP)
+	CALL	·handleHypervisorCallback(SB)
+	ADDQ	$8, SP
+
+	// restore registers
+	MOVQ	0*8(SP), R15
+	MOVQ	1*8(SP), R14
+	MOVQ	2*8(SP), R13
+	MOVQ	3*8(SP), R12
+	MOVQ	4*8(SP), BP
+	MOVQ	5*8(SP), BX
+	MOVQ	6*8(SP), R11
+	MOVQ	7*8(SP), R10
+	MOVQ	8*8(SP), R9
+	MOVQ	9*8(SP), R8
+	MOVQ	10*8(SP), AX
+	MOVQ	11*8(SP), CX
+	MOVQ	12*8(SP), DX
+	MOVQ	13*8(SP), SI
+	MOVQ	14*8(SP), DI
+	ADDQ	$15*8, SP	// registers
+
+	ADDQ	$0x8, SP	// ignore code
+
+	PUSHQ	AX
+	MOVQ	·_atman_shared_info(SB), AX
+	MOVB	$0x0, 0x1(AX)
+	POPQ	AX
+
+	// Correct CS and SS for return to kernel space
+	ORB	$3, 1*8(SP)
+	ORB	$3, 4*8(SP)
+
+	IRETQ
+	RET
+
+TEXT ·hypervisorFailsafeCallback(SB),NOSPLIT,$0
+	IRETQ
+	RET

--- a/src/runtime/hypercall_atman.go
+++ b/src/runtime/hypercall_atman.go
@@ -101,3 +101,17 @@ func HYPERVISOR_sched_op(op uintptr, arg unsafe.Pointer) uintptr {
 		0,
 	)
 }
+
+func HYPERVISOR_set_callbacks(eventCallbackAddr, failsafeCallbackAddr uintptr) uintptr {
+	const _HYPERVISOR_set_callbacks = 4
+
+	return hypercall(
+		_HYPERVISOR_set_callbacks,
+		eventCallbackAddr,
+		failsafeCallbackAddr,
+		0,
+		0,
+		0,
+		0,
+	)
+}

--- a/src/runtime/sched_atman.go
+++ b/src/runtime/sched_atman.go
@@ -70,8 +70,10 @@ func taskcreate(mp, g0, fn, stk unsafe.Pointer) {
 
 	t.ID = taskid
 	t.Context = Context{
-		rsp: uintptr(stk),
-		rip: funcPC(taskstart),
+		cpuRegisters: cpuRegisters{
+			rsp: uintptr(stk),
+			rip: funcPC(taskstart),
+		},
 	}
 	t.semawaiter.task = t
 
@@ -247,14 +249,17 @@ func (l *TaskList) AddByWakeAt(t *Task) {
 
 // Context describes the state of a task
 // for saving or restoring a task's execution context.
-type Context cpuRegisters
+type Context struct {
+	cpuRegisters
+	tls uintptr
+}
 
 func (c *Context) debug() {
 	print(
 		"Context{",
 		"rsp=", unsafe.Pointer(c.rsp),
 		" rip=", unsafe.Pointer(c.rip),
-		" fs=", unsafe.Pointer(c.fs),
+		" tls=", unsafe.Pointer(c.tls),
 		"}", "\n",
 	)
 }
@@ -292,8 +297,30 @@ type cpuRegisters struct {
 	rflags uintptr
 	rsp    uintptr
 	ss     uintptr
-	es     uintptr
-	ds     uintptr
-	fs     uintptr
-	gs     uintptr
+}
+
+func (r *cpuRegisters) debug() {
+	print("cpuRegisters<", unsafe.Pointer(r), "> {")
+	print(" r15=", unsafe.Pointer(r.r15))
+	print(" r14=", unsafe.Pointer(r.r14))
+	print(" r13=", unsafe.Pointer(r.r13))
+	print(" r12=", unsafe.Pointer(r.r12))
+	print(" rbp=", unsafe.Pointer(r.rbp))
+	print(" rbx=", unsafe.Pointer(r.rbx))
+	print(" r11=", unsafe.Pointer(r.r11))
+	print(" r10=", unsafe.Pointer(r.r10))
+	print(" r9=", unsafe.Pointer(r.r9))
+	print(" r8=", unsafe.Pointer(r.r8))
+	print(" rax=", unsafe.Pointer(r.rax))
+	print(" rcx=", unsafe.Pointer(r.rcx))
+	print(" rdx=", unsafe.Pointer(r.rdx))
+	print(" rsi=", unsafe.Pointer(r.rsi))
+	print(" rdi=", unsafe.Pointer(r.rdi))
+	print(" code=", unsafe.Pointer(r.code))
+	print(" rip=", unsafe.Pointer(r.rip))
+	print(" cs=", unsafe.Pointer(r.cs))
+	print(" rflags=", unsafe.Pointer(r.rflags))
+	print(" rsp=", unsafe.Pointer(r.rsp))
+	print(" ss=", unsafe.Pointer(r.ss))
+	print(" }\n")
 }

--- a/src/runtime/sched_atman_amd64.s
+++ b/src/runtime/sched_atman_amd64.s
@@ -42,7 +42,7 @@ TEXT ·contextsave(SB),NOSPLIT,$0-16
 	RDMSR
 	SHLQ	$32, DX	// DX <<= 32
 	ADDQ	DX, AX	// AX = DX + AX
-	MOVQ	AX, 184(DI)	// save tls
+	MOVQ	AX, 168(DI)	// save tls
 
 	MOVQ	$0, ret+8(FP)
 	RET
@@ -52,7 +52,7 @@ TEXT ·contextload(SB),NOSPLIT,$0-8
 	MOVQ	ctx+0(FP), DI
 	MOVQ	152(DI), R8	// save sp
 	MOVQ	128(DI), R9	// save ip
-	MOVQ	184(DI), DI
+	MOVQ	168(DI), DI
 	CALL	runtime·settls(SB) // restore tls
 	MOVQ	R8, SP
 	MOVQ	R9, (SP)	// set return address

--- a/src/runtime/sys_atman.go
+++ b/src/runtime/sys_atman.go
@@ -144,6 +144,8 @@ func atmaninit() {
 	mapSharedInfo(_atman_start_info.SharedInfoAddr)
 
 	_atman_mm.init()
+
+	initEvents()
 }
 
 func mapSharedInfo(vaddr uintptr) {


### PR DESCRIPTION
This adds support for registering hypervisor event callbacks, and sets
up an empty VIRQ timer binding.

It also updates `cpuRegisters` to match all registers plus an interrupt
frame. TLS storage for tasks is no longer stored in a register field in
this structure, but instead `Context` has a separate TLS field.

This partially satisfies #8.
