### PR TITLE
Block VM if all tasks are sleeping

### DIFF
--- a/src/runtime/hypercall_atman.go
+++ b/src/runtime/hypercall_atman.go
@@ -88,6 +88,20 @@ func HYPERVISOR_mmuext_op(ops []mmuExtOp, domid uint16) uintptr {
 	)
 }
 
+func HYPERVISOR_set_timer_op(timeout int64) uintptr {
+	const _HYPERVISOR_set_timer_op = 15
+
+	return hypercall(
+		_HYPERVISOR_set_timer_op,
+		uintptr(timeout),
+		0,
+		0,
+		0,
+		0,
+		0,
+	)
+}
+
 func HYPERVISOR_sched_op(op uintptr, arg unsafe.Pointer) uintptr {
 	const _HYPERVISOR_sched_op = 29
 

--- a/src/runtime/sched_atman.go
+++ b/src/runtime/sched_atman.go
@@ -113,7 +113,8 @@ func taskswitch() {
 			panic("No runnable or timed sleep tasks to run")
 		}
 
-		HYPERVISOR_sched_op(0, nil) // yield
+		HYPERVISOR_set_timer_op(tasksleepqueue.Head.WakeAt)
+		HYPERVISOR_sched_op(1, nil) // block
 	}
 
 	taskcurrent = tasknext


### PR DESCRIPTION
We were previously running with a busy loop while waiting for sleeping tasks to
be runnable. That means that simple programs like the hello example (which
prints the current time every 5 seconds) could use almost 100% CPU while
running.

Now if all tasks are sleeping, we schedule a timer event for the next time a
task is runnable, and then block to wait for the event. The hello program now
uses effectively 0% CPU.

Resolves #12.
