### PR TITLE
println writes to user console

### DIFF
--- a/src/runtime/print1_write_atman.go
+++ b/src/runtime/print1_write_atman.go
@@ -1,11 +1,5 @@
 package runtime
 
-import "unsafe"
-
 func writeErr(b []byte) {
-	HYPERVISOR_console_io(
-		0,
-		uint64(len(b)),
-		uintptr(unsafe.Pointer(&b[0])),
-	)
+	_atman_console.write(b)
 }

--- a/src/runtime/sys_atman.go
+++ b/src/runtime/sys_atman.go
@@ -112,6 +112,8 @@ type vcpuInfo struct {
 }
 
 func atmaninit() {
+	_atman_console.init()
+
 	println("Atman OS")
 	println("     ptr_size: ", ptrSize)
 	println("   start_info: ", _atman_start_info)
@@ -137,8 +139,6 @@ func atmaninit() {
 		unsafe.Pointer(_atman_start_info.PageFrameList),
 		int(_atman_start_info.NrPages),
 	)
-
-	_atman_console.init()
 
 	println("mapping _atman_start_info")
 	mapSharedInfo(_atman_start_info.SharedInfoAddr)


### PR DESCRIPTION
Previously, internal log messages printed with `println` were sent to
the debug console. But the Xen debug console is often inaccessible, as
it requires a special build of Xen which is not generally available via
package managers.

Now `println` family functions write to the normal console.

Additionally, console messages now automatically convert `\n` into
`\r\n` to fix console output formatting.
