### PR TITLE
Use IRET to context switch

### DIFF
--- a/src/runtime/atman_asm.h
+++ b/src/runtime/atman_asm.h
@@ -1,0 +1,55 @@
+#define _PAGE_ROUND_UP(REGISTER) \
+	ADDQ	$0x0000000000000fff, REGISTER	\
+	ANDQ	$0xfffffffffffff000, REGISTER
+
+#define CALL_RBX \
+	BYTE $0xff; BYTE $0xd3	// callq *%rbx
+
+#define HYPERCALL(TRAP) \
+	MOVQ	TRAP, CX				\
+	IMULQ	$32, CX					\
+	MOVQ	$runtime·_atman_hypercall_page(SB), BX	\
+	_PAGE_ROUND_UP(BX)				\
+	ADDQ	CX, BX					\
+	CALL_RBX                                        \
+
+#define READ_FS_BASE(r) \
+	MOVQ	$0xc0000100, CX	\ // MSR_FS_BASE
+	RDMSR			\
+	SHLQ	$32, DX		\ // DX <<= 32
+	ADDQ	DX, AX		\ // AX = DX + AX
+	MOVQ	AX, r
+
+#define RESTORE_ALL \
+	MOVQ	(cpuRegisters_rdi)(SP), DI	\
+	MOVQ	(cpuRegisters_rsi)(SP), SI	\
+	MOVQ	(cpuRegisters_rdx)(SP), DX	\
+	MOVQ	(cpuRegisters_rcx)(SP), CX	\
+	MOVQ	(cpuRegisters_rax)(SP), AX	\
+	MOVQ	(cpuRegisters_r8)(SP), R8	\
+	MOVQ	(cpuRegisters_r9)(SP), R9	\
+	MOVQ	(cpuRegisters_r10)(SP), R10	\
+	MOVQ	(cpuRegisters_r11)(SP), R11	\
+	MOVQ	(cpuRegisters_rbx)(SP), BX	\
+	MOVQ	(cpuRegisters_rbp)(SP), BP	\
+	MOVQ	(cpuRegisters_r12)(SP), R12	\
+	MOVQ	(cpuRegisters_r13)(SP), R13	\
+	MOVQ	(cpuRegisters_r14)(SP), R14	\
+	MOVQ	(cpuRegisters_r15)(SP), R15	\
+
+#define SAVE_ALL \
+	MOVQ	DI, (cpuRegisters_rdi)(SP)	\
+	MOVQ	SI, (cpuRegisters_rsi)(SP)	\
+	MOVQ	DX, (cpuRegisters_rdx)(SP)	\
+	MOVQ	CX, (cpuRegisters_rcx)(SP)	\
+	MOVQ	AX, (cpuRegisters_rax)(SP)	\
+	MOVQ	R8, (cpuRegisters_r8)(SP)	\
+	MOVQ	R9, (cpuRegisters_r9)(SP)	\
+	MOVQ	R10, (cpuRegisters_r10)(SP)	\
+	MOVQ	R11, (cpuRegisters_r11)(SP)	\
+	MOVQ	BX, (cpuRegisters_rbx)(SP)	\
+	MOVQ	BP, (cpuRegisters_rbp)(SP)	\
+	MOVQ	R12, (cpuRegisters_r12)(SP)	\
+	MOVQ	R13, (cpuRegisters_r13)(SP)	\
+	MOVQ	R14, (cpuRegisters_r14)(SP)	\
+	MOVQ	R15, (cpuRegisters_r15)(SP)

--- a/src/runtime/event_atman_amd64.s
+++ b/src/runtime/event_atman_amd64.s
@@ -1,3 +1,4 @@
+#include "atman_asm.h"
 #include "go_asm.h"
 #include "go_tls.h"
 #include "textflag.h"
@@ -18,21 +19,7 @@ TEXT ·eventCallbackASM(SB),NOSPLIT,$0
 	// Save registers to stack
 	SUBQ	$(cpuRegisters_code+8), SP
 	MOVQ	$0x0, (cpuRegisters_code)(SP)
-	MOVQ	DI, (cpuRegisters_rdi)(SP)
-	MOVQ	SI, (cpuRegisters_rsi)(SP)
-	MOVQ	DX, (cpuRegisters_rdx)(SP)
-	MOVQ	CX, (cpuRegisters_rcx)(SP)
-	MOVQ	AX, (cpuRegisters_rax)(SP)
-	MOVQ	R8, (cpuRegisters_r8)(SP)
-	MOVQ	R9, (cpuRegisters_r9)(SP)
-	MOVQ	R10, (cpuRegisters_r10)(SP)
-	MOVQ	R11, (cpuRegisters_r11)(SP)
-	MOVQ	BX, (cpuRegisters_rbx)(SP)
-	MOVQ	BP, (cpuRegisters_rbp)(SP)
-	MOVQ	R12, (cpuRegisters_r12)(SP)
-	MOVQ	R13, (cpuRegisters_r13)(SP)
-	MOVQ	R14, (cpuRegisters_r14)(SP)
-	MOVQ	R15, (cpuRegisters_r15)(SP)
+	SAVE_ALL
 
 	// Save stack pointer
 	MOVQ	SP, CX
@@ -57,22 +44,7 @@ TEXT ·eventCallbackASM(SB),NOSPLIT,$0
 	// Restore original stack pointer
 	MOVQ	0(SP), SP
 
-	// Restore registers from stack
-	MOVQ	(cpuRegisters_rdi)(SP), DI
-	MOVQ	(cpuRegisters_rsi)(SP), SI
-	MOVQ	(cpuRegisters_rdx)(SP), DX
-	MOVQ	(cpuRegisters_rcx)(SP), CX
-	MOVQ	(cpuRegisters_rax)(SP), AX
-	MOVQ	(cpuRegisters_r8)(SP), R8
-	MOVQ	(cpuRegisters_r9)(SP), R9
-	MOVQ	(cpuRegisters_r10)(SP), R10
-	MOVQ	(cpuRegisters_r11)(SP), R11
-	MOVQ	(cpuRegisters_rbx)(SP), BX
-	MOVQ	(cpuRegisters_rbp)(SP), BP
-	MOVQ	(cpuRegisters_r12)(SP), R12
-	MOVQ	(cpuRegisters_r13)(SP), R13
-	MOVQ	(cpuRegisters_r14)(SP), R14
-	MOVQ	(cpuRegisters_r15)(SP), R15
+	RESTORE_ALL
 	ADDQ	$(cpuRegisters_code+8), SP
 
 	PUSHQ	AX

--- a/src/runtime/sched_atman_amd64.s
+++ b/src/runtime/sched_atman_amd64.s
@@ -1,12 +1,13 @@
+#include "atman_asm.h"
 #include "go_asm.h"
 #include "go_tls.h"
 #include "textflag.h"
 
-// func taskstart(fn, _, mp, gp unsafe.Pointer)
+// func taskstart(fn, mp, gp unsafe.Pointer)
 TEXT ·taskstart(SB),NOSPLIT,$0-24
 	MOVQ	(SP), R12
-	MOVQ	16(SP), R8
-	MOVQ	24(SP), R9
+	MOVQ	8(SP), R8
+	MOVQ	16(SP), R9
 
 	// set m->procid to current task ID
 	MOVQ	$runtime·taskcurrent(SB), BX
@@ -31,30 +32,41 @@ TEXT ·taskstart(SB),NOSPLIT,$0-24
 
 	RET // unreachable
 
-// func contextsave(*Context) int
+// func contextsave(ctx *Context, after uintptr)
 TEXT ·contextsave(SB),NOSPLIT,$0-16
 	MOVQ	ctx+0(FP), DI
+
 	MOVQ	(SP), CX
 	MOVQ	CX, (Context_r+cpuRegisters_rip)(DI)
-	MOVQ	SP, (Context_r+cpuRegisters_rsp)(DI)
 
-	MOVQ	$0xc0000100, CX	// MSR_FS_BASE
-	RDMSR
-	SHLQ	$32, DX	// DX <<= 32
-	ADDQ	DX, AX	// AX = DX + AX
+	MOVW	CS, (Context_r+cpuRegisters_cs)(DI)
+	MOVW	SS, (Context_r+cpuRegisters_ss)(DI)
+
+	PUSHFQ
+	MOVQ	(SP), CX
+	MOVQ	CX, (Context_r+cpuRegisters_rflags)(DI)
+	POPFQ
+
+	MOVQ	SP, CX	// Save SP without return address
+	ADDQ	$8, CX
+	MOVQ	CX, (Context_r+cpuRegisters_rsp)(DI)
+
+	READ_FS_BASE(AX)
 	MOVQ	AX, (Context_tls)(DI)
 
-	MOVQ	$0, ret+8(FP)
+	MOVQ	after+8(FP), CX
+	CMPQ	CX, $0
+	JZ	skipcallback
+	CALL	CX
+
+skipcallback:
 	RET
 
 // func contextload(*Context)
 TEXT ·contextload(SB),NOSPLIT,$0-8
-	MOVQ	ctx+0(FP), DI
-	MOVQ	(Context_r+cpuRegisters_rsp)(DI), R8
-	MOVQ	(Context_r+cpuRegisters_rip)(DI), R9
-	MOVQ	(Context_tls)(DI), DI
+	MOVQ	ctx+0(FP), SP
+	MOVQ	(Context_tls)(SP), DI
 	CALL	runtime·settls(SB)
-	MOVQ	R8, SP
-	MOVQ	R9, (SP)	// set return address
-	MOVQ	$1, 16(SP)	// set return value
-	RET
+	RESTORE_ALL
+	ADDQ	$(cpuRegisters_code+8), SP
+	IRETQ

--- a/src/runtime/sys_atman_amd64.s
+++ b/src/runtime/sys_atman_amd64.s
@@ -1,19 +1,5 @@
+#include "atman_asm.h"
 #include "textflag.h"
-
-#define _PAGE_ROUND_UP(REGISTER) \
-	ADDQ	$0x0000000000000fff, REGISTER	\
-	ANDQ	$0xfffffffffffff000, REGISTER
-
-#define CALL_RBX \
-	BYTE $0xff; BYTE $0xd3	// callq *%rbx
-
-#define HYPERCALL(TRAP) \
-	MOVQ	TRAP, CX				\
-	IMULQ	$32, CX					\
-	MOVQ	$runtime·_atman_hypercall_page(SB), BX	\
-	_PAGE_ROUND_UP(BX)				\
-	ADDQ	CX, BX					\
-	CALL_RBX                                        \
 
 TEXT runtime·exit(SB),NOSPLIT,$8-4
 retry:


### PR DESCRIPTION
We were previously using a context switching method modeled on ucontext,
with load and save functions which, when paired together, could swap
contexts.

This had a few problems:
- It required that we be a bit tricky with our function signatures, to
  handle the fact that Go handles return values via the stack, instead
  of through a register like C.
- It was not general purpose, in that the saved contexts only worked
  when the load and save functions were paired. This prevented us
  from, for example, adding interrupt-based preemption, as a preempted
  context could not be loaded with `contextload`, nor could a saved
  context be used to return from an interrupt.

This changeset addresses these problems. It also extracts `atman_asm.h`
for sharing assembly macros.
