### PR TITLE
runtime: remove hard-coded opcode macro in hypercall

### DIFF
--- a/src/runtime/atman_asm.h
+++ b/src/runtime/atman_asm.h
@@ -2,16 +2,13 @@
 	ADDQ	$0x0000000000000fff, REGISTER	\
 	ANDQ	$0xfffffffffffff000, REGISTER
 
-#define CALL_RBX \
-	BYTE $0xff; BYTE $0xd3	// callq *%rbx
-
 #define HYPERCALL(TRAP) \
 	MOVQ	TRAP, CX				\
 	IMULQ	$32, CX					\
 	MOVQ	$runtime·_atman_hypercall_page(SB), BX	\
 	_PAGE_ROUND_UP(BX)				\
 	ADDQ	CX, BX					\
-	CALL_RBX                                        \
+        CALL    BX
 
 #define READ_FS_BASE(r) \
 	MOVQ	$0xc0000100, CX	\ // MSR_FS_BASE


### PR DESCRIPTION
There was a macro here to CALL RBX; this is a vendor-specific spelling
of CALL BX.  BX, EBX, RBX are all effectively synonyms for the same
register, and which one it means depends on the CPU word length mode
in effect and any length prefixes.
