### PR TITLE
runtime: parse command-line arguments

### DIFF
--- a/src/os/sys_atman.go
+++ b/src/os/sys_atman.go
@@ -1,9 +1,5 @@
 package os
 
-func init() {
-	Args = []string{"atmanos"}
-}
-
 func hostname() (name string, err error) {
 	return "atman", nil
 }

--- a/src/runtime/os1_atman.go
+++ b/src/runtime/os1_atman.go
@@ -12,6 +12,30 @@ func osinit() {
 	atmaninit()
 }
 
+func init() {
+	parseCommandLine(_atman_start_info.CmdLine[:])
+}
+
+// parseCommandLine parses kernel arguments passed to the VM
+// and appends them to argslice, which causes them to be visible
+// as os.Args.
+func parseCommandLine(cmdline []byte) {
+	argslice = append(argslice, "atmanos")
+
+	var start int
+	for i := 0; i < len(cmdline); i++ {
+		if cmdline[i] == 0 {
+			argslice = append(argslice, string(cmdline[start:i]))
+			break
+		}
+
+		if cmdline[i] == ' ' {
+			argslice = append(argslice, string(cmdline[start:i]))
+			start = i + 1
+		}
+	}
+}
+
 func sigpanic() {}
 
 func signame(sig uint32) string { return "" }


### PR DESCRIPTION
runtime now parses kernel boot arguments provided to the VM so they are
available to os.Args.

Arguments are passed through the `extra` configuration field in Xen
configurations. There is no program name set in the boot info, so
`os.Args[0]` is always set to "atmanos".

```
startvm hello -c "extra = '-test.flag other args'"
...
os.Args = []string{"atmanos", "-test.flag", "other", "args"}
```

Resolves #2.