### PR TITLE
Enable networking in VM and atman images

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,10 @@ Vagrant.configure(2) do |config|
     sudo apt-get update
     sudo apt-get install -y xen-hypervisor-4.4-amd64 gdb
     sed -i '1s|^|export PATH=$HOME/atman/bin:$PATH\\n|' .bashrc
+
+    sudo ln -nsf /home/vagrant/atman/net/xenbr0.cfg /etc/network/interfaces.d/xenbr0.cfg
+    sudo ln -nsf /home/vagrant/atman/net/xenbr0-up /etc/network/if-up.d/xenbr0-up
+
     sudo reboot
   SHELL
 end

--- a/vagrant/net/xenbr0-up
+++ b/vagrant/net/xenbr0-up
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Start xenbr0 after eth0 is up. Used instead of `auto xenbr0` in
+# the interface config to work around issues with cloud-init
+# and non-physical auto interfaces.
+
+[ "$IFACE" != "eth0" ] || exit 0
+
+ifup xenbr0

--- a/vagrant/net/xenbr0.cfg
+++ b/vagrant/net/xenbr0.cfg
@@ -1,0 +1,2 @@
+iface xenbr0 inet dhcp
+  bridge_ports eth0

--- a/vagrant/template.xl
+++ b/vagrant/template.xl
@@ -1,4 +1,6 @@
 vcpus = 1
 memory = 16
 
+vif = [ 'bridge=xenbr0' ]
+
 on_crash = 'preserve'


### PR DESCRIPTION
This updates the Vagrant provisioner to configure a bridge network for
Xen and updates the default `template.xl` Xen configuration to use the
bridge.

This should allow networking example programs to work out-of-the-box.

This resolves #25, including the slow boot times.