### PR TITLE
runtime: fix test build and patch testenv

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -3,4 +3,4 @@ set -e
 make
 bin/atman test -c runtime -o vagrant/images/runtime.test
 vagrant rsync
-vagrant ssh --command 'startvm runtime.test -c "memory = 32"'
+vagrant ssh --command "startvm runtime.test -c \"extra = '-test.v -test.short $*'\" \"memory = 256\""

--- a/patches/internal.diff
+++ b/patches/internal.diff
@@ -1,0 +1,48 @@
+diff --git a/src/internal/testenv/testenv.go b/src/internal/testenv/testenv.go
+index f7c4ad2..3ba24a3 100644
+--- a/src/internal/testenv/testenv.go
++++ b/src/internal/testenv/testenv.go
+@@ -34,7 +34,7 @@ func Builder() string {
+ // and then run them with os.StartProcess or exec.Command.
+ func HasGoBuild() bool {
+ 	switch runtime.GOOS {
+-	case "android", "nacl":
++	case "android", "nacl", "atman":
+ 		return false
+ 	case "darwin":
+ 		if strings.HasPrefix(runtime.GOARCH, "arm") {
+@@ -104,7 +104,7 @@ func GoTool() (string, error) {
+ // using os.StartProcess or (more commonly) exec.Command.
+ func HasExec() bool {
+ 	switch runtime.GOOS {
+-	case "nacl":
++	case "nacl", "atman":
+ 		return false
+ 	case "darwin":
+ 		if strings.HasPrefix(runtime.GOARCH, "arm") {
+@@ -167,7 +167,11 @@ func HasLink() bool {
+ 	// From Android release M (Marshmallow), hard linking files is blocked
+ 	// and an attempt to call link() on a file will return EACCES.
+ 	// - https://code.google.com/p/android-developer-preview/issues/detail?id=3150
+-	return runtime.GOOS != "plan9" && runtime.GOOS != "android"
++	switch runtime.GOOS {
++	case "android", "plan9", "atman":
++		return false
++	}
++	return true
+ }
+ 
+ // MustHaveLink reports whether the current system can use os.Link.
+diff --git a/src/internal/testenv/testenv_notwin.go b/src/internal/testenv/testenv_notwin.go
+index d8ce6cd..eb41157 100644
+--- a/src/internal/testenv/testenv_notwin.go
++++ b/src/internal/testenv/testenv_notwin.go
+@@ -12,7 +12,7 @@ import (
+ 
+ func hasSymlink() (ok bool, reason string) {
+ 	switch runtime.GOOS {
+-	case "android", "nacl", "plan9":
++	case "android", "nacl", "plan9", "atman":
+ 		return false, ""
+ 	}
+ 

--- a/patches/runtime_goos_atman.diff
+++ b/patches/runtime_goos_atman.diff
@@ -1,3 +1,16 @@
+diff --git a/src/runtime/crash_nonunix_test.go b/src/runtime/crash_nonunix_test.go
+index 2ce995c..3689ac4 100644
+--- a/src/runtime/crash_nonunix_test.go
++++ b/src/runtime/crash_nonunix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build windows plan9 nacl
++// +build windows plan9 nacl atman
+ 
+ package runtime_test
+ 
 diff --git a/src/runtime/lock_sema.go b/src/runtime/lock_sema.go
 index 0fa0481..42834cf 100644
 --- a/src/runtime/lock_sema.go

--- a/src/os/exec_atman.go
+++ b/src/os/exec_atman.go
@@ -2,6 +2,8 @@ package os
 
 import "time"
 
+var Kill Signal
+
 func (p *Process) signal(sig Signal) error {
 	return nil
 }


### PR DESCRIPTION
* bin/test passes useful default arguments to test binary and Xen
* runtime tests compile
* adds atman to list of GOOS that don't support link, build, or exec

The tests themselves don't fully, and some like `TestYieldProgress` produce hot CPU loops due to lack of preemptive thread scheduling, but it's a start!